### PR TITLE
Remove references to HM CMB

### DIFF
--- a/kapow-skeleton/composer.json
+++ b/kapow-skeleton/composer.json
@@ -48,9 +48,6 @@
             ],
             "build/wp-content/themes/{$name}": [
                 "type:wordpress-theme"
-            ],
-            "build/wp-content/mu-plugins/humanmade/custom-meta-boxes": [
-                "humanmade/custom-meta-boxes"
             ]
         }
     },


### PR DESCRIPTION
We do not always use HM CMB, so references removed so it doesn't automatically get installed when we initiate the project